### PR TITLE
Rm total_searches from search_clients_last_seen

### DIFF
--- a/sql/search_derived/search_clients_last_seen_v1/query.sql
+++ b/sql/search_derived/search_clients_last_seen_v1/query.sql
@@ -1,10 +1,6 @@
 WITH _derived_search_cols AS (
   SELECT
     udf.normalize_search_engine(engine) AS short_engine,
-    COALESCE(organic, 0) + COALESCE(sap, 0) + COALESCE(unknown, 0) + COALESCE(
-      tagged_sap,
-      0
-    ) + COALESCE(tagged_follow_on, 0) AS total_searches,
     COALESCE(tagged_sap, 0) + COALESCE(tagged_follow_on, 0) AS tagged_searches,
     COALESCE(ad_click, 0) AS ad_click,
     COALESCE(search_with_ads, 0) AS search_with_ads,


### PR DESCRIPTION
`total_searches` sums up fields that are repetitive and should not be summed together. This is misleading to the naive analyst, and should be removed from the table.